### PR TITLE
Jdk16+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 graalvm*
 tech.v3.datatype.main
 resources
+jdk-16

--- a/project.clj
+++ b/project.clj
@@ -15,14 +15,15 @@
                  [techascent/tech.resource         "5.02"]
                  [techascent/tech.jna "4.05" :scope "provided"]]
   :java-source-paths ["java"]
-  :jvm-opts ["--add-modules" "jdk.incubator.foreign" "-Dforeign.restricted=permit"]
-  :source-paths ["src" "src_jdk_16"]
+  :source-paths ["src"]
   :profiles {:dev
              {:dependencies [[criterium "0.4.5"]
                              [uncomplicate/neanderthal "0.35.0"]
                              [com.taoensso/nippy "3.1.0-RC1"]
                              [ch.qos.logback/logback-classic "1.1.3"]]
               :test-paths ["neanderthal" "test"]}
+             :jdk-16 {:jvm-opts ["--add-modules" "jdk.incubator.foreign" "-Dforeign.restricted=permit"]
+                      :source-paths ["src" "src_jdk_16"]}
              :codox
              {:dependencies [[codox-theme-rdash "0.1.2"]]
               :plugins [[lein-codox "0.10.7"]]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,6 @@
                  [techascent/tech.resource         "5.02"]
                  [techascent/tech.jna "4.05" :scope "provided"]]
   :java-source-paths ["java"]
-  :javac-options ["--add-modules" "jdk.incubator.foreign"]
   :jvm-opts ["--add-modules" "jdk.incubator.foreign" "-Dforeign.restricted=permit"]
   :source-paths ["src" "src_jdk_16"]
   :profiles {:dev

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.roaringbitmap/RoaringBitmap  "0.9.0"]
                  [techascent/tech.resource         "5.02"]
                  [techascent/tech.jna "4.05" :scope "provided"]]
-  :java-source-paths ["java" "java_jdk16"]
+  :java-source-paths ["java"]
   :javac-options ["--add-modules" "jdk.incubator.foreign"]
   :jvm-opts ["--add-modules" "jdk.incubator.foreign" "-Dforeign.restricted=permit"]
   :source-paths ["src" "src_jdk_16"]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,10 @@
                  [org.roaringbitmap/RoaringBitmap  "0.9.0"]
                  [techascent/tech.resource         "5.02"]
                  [techascent/tech.jna "4.05" :scope "provided"]]
-  :java-source-paths ["java"]
+  :java-source-paths ["java" "java_jdk16"]
+  :javac-options ["--add-modules" "jdk.incubator.foreign"]
+  :jvm-opts ["--add-modules" "jdk.incubator.foreign" "-Dforeign.restricted=permit"]
+  :source-paths ["src" "src_jdk_16"]
   :profiles {:dev
              {:dependencies [[criterium "0.4.5"]
                              [uncomplicate/neanderthal "0.35.0"]

--- a/scripts/enable-jdk16
+++ b/scripts/enable-jdk16
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ ! -e jdk-16 ]; then
+    get-jdk-16
+fi
 
 export PATH=$(pwd)/jdk-16/bin:$PATH
 export JAVA_HOME=$(pwd)/jdk-16/

--- a/scripts/enable-jdk16
+++ b/scripts/enable-jdk16
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+
+export PATH=$(pwd)/jdk-16/bin:$PATH
+export JAVA_HOME=$(pwd)/jdk-16/

--- a/scripts/get-jdk-16
+++ b/scripts/get-jdk-16
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+
+wget https://download.java.net/java/early_access/jdk16/32/GPL/openjdk-16-ea+32_linux-x64_bin.tar.gz
+tar -xvzf openjdk-16-ea+32_linux-x64_bin.tar.gz
+rm tar -xvzf openjdk-16-ea+32_linux-x64_bin.tar.gz

--- a/src/tech/v3/datatype/mmap.clj
+++ b/src/tech/v3/datatype/mmap.clj
@@ -17,14 +17,14 @@
   "Memory map a file returning a native buffer.  fpath must resolve to a valid
    java.io.File.
   Options
-  * :resource-type - maps to tech.v3.resource `:track-type`.
+  * :resource-type - maps to tech.v3.resource `:track-type`, defaults to :auto.
   * :mmap-mode
     * :read-only - default - map the data as shared read-only.
     * :read-write - map the data as shared read-write.
     * :private - map a private copy of the data and do not share."
-  ([fpath {:keys [resource-type mmap-mode endianness]
-           :or {resource-type :gc
-                mmap-mode :read-only}}]
+  (^NativeBuffer [fpath {:keys [resource-type mmap-mode endianness]
+                         :or {resource-type :auto
+                              mmap-mode :read-only}}]
    (let [file (io/file fpath)
          _ (when-not (.exists file)
              (throw (Exception. (format "%s not found" fpath))))
@@ -43,5 +43,5 @@
                         :track-type :stack}))
      (native-buffer/wrap-address (.address map-buf) (.mapSize map-buf) :int8
                                  endianness map-buf)))
-  ([fpath]
+  (^NativeBuffer [fpath]
    (mmap-file fpath {})))

--- a/src/tech/v3/datatype/mmap.clj
+++ b/src/tech/v3/datatype/mmap.clj
@@ -1,0 +1,26 @@
+(ns tech.v3.datatype.mmap
+  (:require [clojure.tools.logging :as log])
+  (:import [tech.v3.datatype.native_buffer NativeBuffer]))
+
+
+(def mmap-fn* (delay (try
+                       (requiring-resolve 'tech.v3.datatype.mmap-larray/mmap-file)
+                       (catch Throwable e
+                         (log/info "Failed to require larray-based mmap -
+falling back to jdk16+ ffi-based mmap")
+                         (requiring-resolve 'tech.v3.datatype.mmap-ffi/mmap-file)))))
+
+
+(defn mmap-file
+  "Memory map a file returning a native buffer.  fpath must resolve to a valid
+   java.io.File.
+  Options
+  * :resource-type - maps to tech.v3.resource `:track-type`, defaults to :auto.
+  * :mmap-mode
+    * :read-only - default - map the data as shared read-only.
+    * :read-write - map the data as shared read-write.
+    * :private - map a private copy of the data and do not share."
+  (^NativeBuffer [fpath options]
+   (@mmap-fn* fpath options))
+  (^NativeBuffer [fpath]
+   (mmap-file fpath {})))

--- a/src/tech/v3/datatype/mmap.clj
+++ b/src/tech/v3/datatype/mmap.clj
@@ -4,11 +4,14 @@
 
 
 (def mmap-fn* (delay (try
-                       (requiring-resolve 'tech.v3.datatype.mmap-larray/mmap-file)
+                       (let [retval (requiring-resolve 'tech.v3.datatype.mmap-larray/mmap-file)]
+                         (when-not retval
+                           (throw (Exception. "failed to load mmap-larray namespace")))
+                         retval)
                        (catch Throwable e
                          (log/info "Failed to require larray-based mmap -
 falling back to jdk16+ ffi-based mmap")
-                         (requiring-resolve 'tech.v3.datatype.mmap-ffi/mmap-file)))))
+                         (requiring-resolve 'tech.v3.datatype.mmap-mmodel/mmap-file)))))
 
 
 (defn mmap-file

--- a/src/tech/v3/datatype/mmap.clj
+++ b/src/tech/v3/datatype/mmap.clj
@@ -1,17 +1,12 @@
 (ns tech.v3.datatype.mmap
-  (:require [clojure.tools.logging :as log])
+  (:require [tech.v3.datatype.native-buffer]
+            [clojure.tools.logging :as log])
   (:import [tech.v3.datatype.native_buffer NativeBuffer]))
 
 
-(def mmap-fn* (delay (try
-                       (let [retval (requiring-resolve 'tech.v3.datatype.mmap-larray/mmap-file)]
-                         (when-not retval
-                           (throw (Exception. "failed to load mmap-larray namespace")))
-                         retval)
-                       (catch Throwable e
-                         (log/info "Failed to require larray-based mmap -
-falling back to jdk16+ ffi-based mmap")
-                         (requiring-resolve 'tech.v3.datatype.mmap-mmodel/mmap-file)))))
+(def mmap-fn* (delay (if (.startsWith (System/getProperty "java.version") "16-")
+                       (requiring-resolve 'tech.v3.datatype.mmap-mmodel/mmap-file)
+                       (requiring-resolve 'tech.v3.datatype.mmap-larray/mmap-file))))
 
 
 (defn mmap-file

--- a/src/tech/v3/datatype/mmap_larray.clj
+++ b/src/tech/v3/datatype/mmap_larray.clj
@@ -1,4 +1,4 @@
-(ns tech.v3.datatype.mmap
+(ns tech.v3.datatype.mmap-larray
   "Bindings to an mmap pathway (provided by xerial.larray.mmap)."
   (:require [clojure.java.io :as io]
             [tech.v3.resource :as resource]

--- a/src/tech/v3/datatype/mmap_larray.clj
+++ b/src/tech/v3/datatype/mmap_larray.clj
@@ -7,6 +7,7 @@
             [tech.v3.datatype.protocols :as dtype-proto])
   (:import [xerial.larray.mmap MMapMode]
            [tech.v3.datatype MMapBuffer]
+           [tech.v3.datatype.native_buffer NativeBuffer]
            [sun.misc Unsafe]))
 
 

--- a/src/tech/v3/tensor.clj
+++ b/src/tech/v3/tensor.clj
@@ -922,7 +922,10 @@
             rank# (long ~rank)
             n-elems# (long (apply * shape#))
             dims# (dims/dimensions shape#)]
-        (reify ~read-type
+        (reify
+          dtype-proto/PECount
+          (ecount [this#] (.lsize this#))
+          ~read-type
           (elemwiseDatatype [tr#] ~advertised-datatype)
           (shape [tr#] shape#)
           (dimensions [tr#] dims#)

--- a/src/tech/v3/tensor/dimensions/global_to_local.clj
+++ b/src/tech/v3/tensor/dimensions/global_to_local.clj
@@ -321,6 +321,7 @@
 
 (comment
   (require '[tech.v3.tensor.dimensions :as dims])
+  (require '[tech.v3.tensor.dimensions.gtol-insn :as gtol])
 
   ;;Image dimensions when you have a 2048x2048 image and you
   ;;want to crop a 256x256 sub-image out of it.
@@ -328,10 +329,10 @@
                     (dims/rotate [0 0 1])
                     (dims/broadcast [4 4 4])))
   (def reduced-dims (dims-analytics/reduce-dimensionality src-dims))
+  (def method-sig (reduced-dims->signature reduced-dims))
+  (def test-ast (gtol/signature->ast method-sig))
 
-  (def test-ast (global->local-ast reduced-dims))
-
-  (def class-def (gen-ast-class-def test-ast))
+  (def class-def (gtol/gen-ast-class-def test-ast))
 
   (def class-obj (insn/define class-def))
 

--- a/src/tech/v3/tensor/dimensions/gtol_insn.clj
+++ b/src/tech/v3/tensor/dimensions/gtol_insn.clj
@@ -351,7 +351,7 @@
      :interfaces [LongReader]
      :fields (vec (emit-fields shape-scalar-vec fields))
      :methods [{:flags #{:public}
-                :name :init
+                :wname :init
                 :desc [(Class/forName "[Ljava.lang.Object;")
                        (Class/forName "[J")
                        (Class/forName "[J")

--- a/src/tech/v3/tensor/dimensions/gtol_insn.clj
+++ b/src/tech/v3/tensor/dimensions/gtol_insn.clj
@@ -351,7 +351,7 @@
      :interfaces [LongReader]
      :fields (vec (emit-fields shape-scalar-vec fields))
      :methods [{:flags #{:public}
-                :wname :init
+                :name :init
                 :desc [(Class/forName "[Ljava.lang.Object;")
                        (Class/forName "[J")
                        (Class/forName "[J")

--- a/src_jdk_16/tech/v3/datatype/ffi.clj
+++ b/src_jdk_16/tech/v3/datatype/ffi.clj
@@ -12,7 +12,6 @@
            [java.nio.file Path Paths]
            [java.lang.reflect Constructor]
            [tech.v3.datatype NumericConversions]
-           [tech.v3.datatype.ffi InvokeStub]
            [clojure.lang IFn RT ISeq Var]))
 
 

--- a/src_jdk_16/tech/v3/datatype/ffi.clj
+++ b/src_jdk_16/tech/v3/datatype/ffi.clj
@@ -1,13 +1,16 @@
 (ns tech.v3.datatype.ffi
   (:require [tech.v3.datatype.base :as dtype-base]
+            [tech.v3.datatype.protocols :as dtype-proto]
             [tech.v3.datatype.errors :as errors]
             [insn.core :as insn]
-            [clojure.string :as s])
+            [clojure.string :as s]
+            [clojure.java.io :as io])
   (:import [jdk.incubator.foreign LibraryLookup CLinker FunctionDescriptor
             MemoryLayout LibraryLookup$Symbol]
-           [jdk.incubator.foreign MemoryAddress]
+           [jdk.incubator.foreign MemoryAddress Addressable]
            [java.lang.invoke MethodHandle MethodType]
            [java.nio.file Path Paths]
+           [java.lang.reflect Constructor]
            [tech.v3.datatype NumericConversions]
            [tech.v3.datatype.ffi InvokeStub]
            [clojure.lang IFn RT ISeq Var]))
@@ -27,9 +30,55 @@
 ;;         FunctionDescriptor.of(C_LONG, C_POINTER)
 ;;     );
 
-(defn memory-layout-array
-  ^"[Ljdk.incubator.foreign.MemoryLayout;" [& args]
-  (into-array MemoryLayout args))
+
+(defprotocol PToMemoryAddress
+  (convertible-to-memory-address? [item]
+    "Is this object convertible to a MemoryAddress?")
+  (->memory-address ^MemoryAddress [item]
+    "Conversion to a MemoryAddress"))
+
+
+(extend-type Object
+  PToMemoryAddress
+  (is-memory-address-convertible? [item]
+    (dtype-proto/convertible-to-native-buffer? item))
+  (->memory-address [item]
+    (let [nbuf (dtype-base/->native-buffer item)]
+      (MemoryAddress/ofLong (.address nbuf)))))
+
+
+(defn ptr-convertible?
+  "Is this object pointer convertible via the PToPtr protocol."
+  [item]
+  (when item (convertible-to-memory-address? item)))
+
+
+(defn as-ptr
+  "Convert this object to a jna Pointer MEmoryAddress that points to 0 if not possible."
+  ^MemoryAddress [item]
+  (if (and item (ptr-convertible? item))
+    (->memory-address item)
+    (MemoryAddress/ofLong 0)))
+
+
+(defn ensure-ptr
+  "Ensure this is a non-nil ptr"
+  [item]
+  (when-not (and item (ptr-convertible? item))
+    (errors/throwf "Item is not pointer convertible: %s" item))
+  (as-ptr item))
+
+
+(extend-protocol PToMemoryAddress
+  MemoryAddress
+  (is-memory-address-convertible? [item] true)
+  (->ptr-backing-store [item] item)
+  Addressable
+  (is-memory-address-convertible? [item] true)
+  (->memory-address [item] (.address item))
+  String
+  (is-memory-address-convertible? [item] true)
+  (->memory-address [item] (.address (CLinker/toCString (str item)))))
 
 (defn ->path
   ^Path [str-base & args]
@@ -37,28 +86,32 @@
 
 (defn find-symbol
   (^LibraryLookup$Symbol [libname symbol-name]
-   (if (instance? java.nio.file.Path libname)
-     (-> (.lookup (LibraryLookup/ofPath libname) symbol-name)
-         (.get))
-     (-> (.lookup (LibraryLookup/ofLibrary libname) symbol-name)
-         (.get))))
+   (let [symbol-name (cond
+                       (symbol? symbol-name)
+                       (name symbol-name)
+                       (keyword? symbol-name)
+                       (name symbol-name)
+                       :else
+                       (str symbol-name))]
+     (cond
+       (instance? java.nio.file.Path libname)
+       (-> (.lookup (LibraryLookup/ofPath libname) symbol-name)
+           (.get))
+       (string? libname)
+       (-> (.lookup (LibraryLookup/ofLibrary libname) symbol-name)
+           (.get))
+       (nil? libname)
+       (-> (.lookup (LibraryLookup/ofDefault) symbol-name)
+           (.get))
+       :else
+       (errors/throwf "Inrecognized libname type: %s"))))
   (^LibraryLookup$Symbol [symbol-name]
-   (-> (.lookup (LibraryLookup/ofDefault) (str symbol-name))
-       (.get))))
+   (find-symbol nil symbol-name)))
 
 
-(defn ->memory-address
-  [item]
-  (cond
-    (nil? item)
-    (MemoryAddress/ofLong 0)
-    (string? item)
-    (.address (CLinker/toCString item))
-    :else
-    (if-let [nbuf (dtype-base/as-native-buffer item)]
-      (MemoryAddress/ofLong (.address nbuf))
-      (errors/throwf "Item type %s is not convertible to memory address"
-                     (type item)))))
+(defn memory-layout-array
+  ^"[Ljdk.incubator.foreign.MemoryLayout;" [& args]
+  (into-array MemoryLayout args))
 
 
 (defn argtype->mem-layout-type
@@ -120,8 +173,6 @@
                 "V")))
        (s/join "_")))
 
-(def constructor-code
-  )
 
 (defn argtype->insn-type
   [argtype]
@@ -148,18 +199,18 @@
                     (concat
                      [[:aload arg-idx]]
                      (case argtype
-                       :int8 [[:invokestatic NumericConversions "numberCast" [:object Number]]
-                              [:invokestatic RT "uncheckedByteCast" [:object Byte/TYPE]]]
-                       :int16 [[:invokestatic NumericConversions "numberCast" [:object Number]]
-                               [:invokestatic RT "uncheckedShortCast" [:object Short/TYPE]]]
-                       :int32 [[:invokestatic NumericConversions "numberCast" [:object Number]]
-                               [:invokestatic RT "uncheckedIntCast" [:object Integer/TYPE]]]
-                       :int64 [[:invokestatic NumericConversions "numberCast" [:object Number]]
-                               [:invokestatic RT "uncheckedIntCast" [:object Long/TYPE]]]
-                       :float32 [[:invokestatic NumericConversions "numberCast" [:object Number]]
-                                 [:invokestatic RT "uncheckedFloatCast" [:object Float/TYPE]]]
-                       :float64 [[:invokestatic NumericConversions "numberCast" [:object Number]]
-                                 [:invokestatic RT "uncheckedDoubleCast" [:object Double/TYPE]]]
+                       :int8 [[:invokestatic NumericConversions "numberCast" [Object Number]]
+                              [:invokestatic RT "uncheckedByteCast" [Object Byte/TYPE]]]
+                       :int16 [[:invokestatic NumericConversions "numberCast" [Object Number]]
+                               [:invokestatic RT "uncheckedShortCast" [Object Short/TYPE]]]
+                       :int32 [[:invokestatic NumericConversions "numberCast" [Object Number]]
+                               [:invokestatic RT "uncheckedIntCast" [Object Integer/TYPE]]]
+                       :int64 [[:invokestatic NumericConversions "numberCast" [Object Number]]
+                               [:invokestatic RT "uncheckedLongCast" [Object Long/TYPE]]]
+                       :float32 [[:invokestatic NumericConversions "numberCast" [Object Number]]
+                                 [:invokestatic RT "uncheckedFloatCast" [Object Float/TYPE]]]
+                       :float64 [[:invokestatic NumericConversions "numberCast" [Object Number]]
+                                 [:invokestatic RT "uncheckedDoubleCast" [Object Double/TYPE]]]
                        [[:aload 0]
                         [:getfield :this "asMemoryAddr" IFn]
                         ;;Swap the IFn 'this' ptr and the argument on the stack
@@ -181,70 +232,125 @@
                         [:areturn]]
               :float64 [[:invokestatic Double "valueOf" [:double Double]]
                         [:areturn]]
-              (if (nil? rettype)
+              (if (or (nil? rettype)
+                      (= :void rettype))
                 [[:return]]
                 [[:areturn]])))]))
 
 
-(defn emit-insn-apply-to
-  [^long n-args]
-  (concat
-   [[:aload 0]
-    [:dup]
-    [:aload 1]]
-   (->> (for [idx (range n-args)]
-          [[:dup]
-           [:invokeinterface ISeq "first" [Object]]
-           [:swap]
-           [:invokeinterface ISeq "next" [ISeq]]])
-        (apply concat))
-   [[:pop]
-    [:invokevirtual :this "invoke" (vec (repeat (inc n-args) Object))]
-    [:areturn]]))
+(defn sig->full-cls-symbol
+  [sig]
+  (symbol (str "tech.v3.datatype.ffi.Invoker_" (sig->cls-name sig))))
 
 
 (defn sig->class-def
   [{:keys [argtypes] :as sig}]
-  (let [cls-name (sig->cls-name sig)]
-    {:name (symbol (str "test.v3.datatype.ffi." cls-name))
-     :interfaces [IFn]
-     :fields [{:flags #{:public :final}
-               :name "methodHandle"
-               :type MethodHandle}
-              {:flags #{:public :final}
-               :name "asMemoryAddr"
-               :type IFn}]
-     :methods [{:flags #{:public}
-                :name :init
-                :desc [MethodHandle IFn :void]
-                :emit [[:aload 0]
-                       [:invokespecial :super :init [:void]]
-                       [:aload 0]
-                       [:aload 1]
-                       [:checkcast MethodHandle]
-                       [:putfield :this "methodHandle" MethodHandle]
-                       [:aload 0]
-                       [:aload 2]
-                       [:checkcast IFn]
-                       [:putfield :this "asMemoryAddr" IFn]
-                       [:return]]}
-               {:flags #{:public}
-                :name :invoke
-                :desc (vec (repeat (inc (count argtypes)) Object))
-                :emit (emit-insn-for-sig sig)}
-               {:flags #{:public}
-                :name :applyTo
-                :desc [ISeq Object]
-                :emit (emit-insn-apply-to (count argtypes))}
-               ]}))
+  {:name (sig->full-cls-symbol sig)
+   :interfaces [IFn]
+   :fields [{:flags #{:public :final}
+             :name "methodHandle"
+             :type MethodHandle}
+            {:flags #{:public :final}
+             :name "asMemoryAddr"
+             :type IFn}]
+   :methods [{:flags #{:public}
+              :name :init
+              :desc [MethodHandle IFn :void]
+              :emit [[:aload 0]
+                     [:invokespecial :super :init [:void]]
+                     [:aload 0]
+                     [:aload 1]
+                     [:checkcast MethodHandle]
+                     [:putfield :this "methodHandle" MethodHandle]
+                     [:aload 0]
+                     [:aload 2]
+                     [:checkcast IFn]
+                     [:putfield :this "asMemoryAddr" IFn]
+                     [:return]]}
+             {:flags #{:public}
+              :name :invoke
+              :desc (vec (repeat (inc (count argtypes)) Object))
+              :emit (emit-insn-for-sig sig)}]})
 
-(defn strlen
-  [data]
-  (let [linker (CLinker/getInstance)
-        symbol (find-symbol "strlen")
-        sig {:rettype :int64 :argtypes [:pointer]}
-        jvm-sig (sig->method-type sig)
-        c-sig (sig->fdesc sig)
-        mh (.downcallHandle linker symbol jvm-sig c-sig)
-        ms (CLinker/toCString (str data))]
-    (InvokeStub/invokeExactJ mh (.address ms))))
+
+(defn find-function
+  "Find the symbol and return an IFn implementation wrapping efficient access
+  to the function."
+  [libname symbol-name rettype argtypes & [invoker-constructor]]
+  (let [sym (find-symbol libname symbol-name)
+        sig {:rettype rettype
+             :argtypes argtypes}
+        fndesc (sig->fdesc sig)
+        methoddesc (sig->method-type sig)
+        linker (CLinker/getInstance)
+        method-handle (.downcallHandle linker sym methoddesc fndesc)
+        invoker-constructor
+        (or invoker-constructor
+            (fn [sig mh ma-fn]
+              (let [fn-invoke-cls (insn/define (sig->class-def sig))
+                    ^Constructor fn-invoke-constructor
+                    (first (.getDeclaredConstructors fn-invoke-cls))]
+                (.newInstance fn-invoke-constructor (object-array [mh ma-fn])))))]
+    (invoker-constructor sig method-handle ->memory-address)))
+
+
+(defn define-and-save
+  "currently broken"
+  [sig]
+  (let [class-def (sig->class-def sig)
+        cls-name (name (:name class-def))
+        lastdot (.lastIndexOf cls-name ".")
+        package (.substring cls-name 0 lastdot)
+        cls-name (.substring cls-name (inc lastdot))
+        output-path (str "target/classes/"
+                         (.replace package "." "/")
+                         "/" cls-name ".class")]
+    (io/make-parents output-path)
+    (insn/write (insn/visit class-def) "target/classes")
+    output-path))
+
+
+
+(defmacro def-ffi-fn
+  [libname symbol-name docstr rettype & arglist]
+  (let [fn-args (mapv second arglist)
+        fn-argtypes (mapv first arglist)
+        sym-name (name symbol-name)]
+    `(let [~'fn-obj* (delay (find-function ~libname ~sym-name
+                                           ~rettype ~fn-argtypes))]
+       (defn ~symbol-name
+         ~docstr
+         ~fn-args
+         ~(if (== 0 (count arglist))
+            `((deref ~'fn-obj*))
+            `((deref ~'fn-obj*) ~@fn-args))))))
+
+(def arch64-set #{"x86_64" "amd64"})
+
+
+(defn size-t-size
+  ^long []
+  (let [arch (.toLowerCase (System/getProperty "os.arch"))]
+    (if (arch64-set arch)
+      8
+      4)))
+
+
+(defmacro size-t-compile-time-switch
+  "Run either int32 based code or int64 based code depending
+   on the runtime size of size-t"
+  [int-body long-body]
+  (case (size-t-size)
+    4 `~int-body
+    8 `~long-body))
+
+
+(defn size-t-type
+  []
+  (if (= (size-t-size) 8)
+    :int64
+    :int32))
+
+(defn ptr-int-type
+  []
+  (size-t-type))

--- a/src_jdk_16/tech/v3/datatype/ffi.clj
+++ b/src_jdk_16/tech/v3/datatype/ffi.clj
@@ -1,0 +1,250 @@
+(ns tech.v3.datatype.ffi
+  (:require [tech.v3.datatype.base :as dtype-base]
+            [tech.v3.datatype.errors :as errors]
+            [insn.core :as insn]
+            [clojure.string :as s])
+  (:import [jdk.incubator.foreign LibraryLookup CLinker FunctionDescriptor
+            MemoryLayout LibraryLookup$Symbol]
+           [jdk.incubator.foreign MemoryAddress]
+           [java.lang.invoke MethodHandle MethodType]
+           [java.nio.file Path Paths]
+           [tech.v3.datatype NumericConversions]
+           [tech.v3.datatype.ffi InvokeStub]
+           [clojure.lang IFn RT ISeq Var]))
+
+
+(set! *warn-on-reflection* true)
+
+;;  https://openjdk.java.net/projects/jdk/16/
+;;  https://download.java.net/java/early_access/jdk16/docs/api/jdk.incubator.foreign/jdk/incubator/foreign/CLinker.html
+;;  https://openjdk.java.net/jeps/389
+;;  https://github.com/cs-activeviam-simd/vector-profiling/blob/master/src/test/java/fr/centralesupelec/simd/VectorOffHeapTest.java
+
+
+;; MethodHandle strlen = CLinker.getInstance().downcallHandle(
+;;         LibraryLookup.ofDefault().lookup("strlen"),
+;;         MethodType.methodType(long.class, MemoryAddress.class),
+;;         FunctionDescriptor.of(C_LONG, C_POINTER)
+;;     );
+
+(defn memory-layout-array
+  ^"[Ljdk.incubator.foreign.MemoryLayout;" [& args]
+  (into-array MemoryLayout args))
+
+(defn ->path
+  ^Path [str-base & args]
+  (Paths/get (str str-base) (into-array String args)))
+
+(defn find-symbol
+  (^LibraryLookup$Symbol [libname symbol-name]
+   (if (instance? java.nio.file.Path libname)
+     (-> (.lookup (LibraryLookup/ofPath libname) symbol-name)
+         (.get))
+     (-> (.lookup (LibraryLookup/ofLibrary libname) symbol-name)
+         (.get))))
+  (^LibraryLookup$Symbol [symbol-name]
+   (-> (.lookup (LibraryLookup/ofDefault) (str symbol-name))
+       (.get))))
+
+
+(defn ->memory-address
+  [item]
+  (cond
+    (nil? item)
+    (MemoryAddress/ofLong 0)
+    (string? item)
+    (.address (CLinker/toCString item))
+    :else
+    (if-let [nbuf (dtype-base/as-native-buffer item)]
+      (MemoryAddress/ofLong (.address nbuf))
+      (errors/throwf "Item type %s is not convertible to memory address"
+                     (type item)))))
+
+
+(defn argtype->mem-layout-type
+  [argtype]
+  (case argtype
+    :int8 CLinker/C_CHAR
+    :int16 CLinker/C_SHORT
+    :int32 CLinker/C_INT
+    :int64 CLinker/C_LONG
+    :float32 CLinker/C_FLOAT
+    :float64 CLinker/C_DOUBLE
+    :pointer? CLinker/C_POINTER
+    :pointer CLinker/C_POINTER))
+
+
+(defn sig->fdesc
+  ^FunctionDescriptor [{:keys [rettype argtypes]}]
+  (if (nil? rettype)
+    (FunctionDescriptor/ofVoid (->> argtypes
+                                    (map argtype->mem-layout-type)
+                                    (apply memory-layout-array)))
+    (FunctionDescriptor/of (argtype->mem-layout-type rettype)
+                           (->> argtypes
+                                (map argtype->mem-layout-type)
+                                (apply memory-layout-array)))))
+
+(defn argtype->cls
+  ^Class [argtype]
+  (case argtype
+    :int8 Byte/TYPE
+    :int16 Short/TYPE
+    :int32 Integer/TYPE
+    :int64 Long/TYPE
+    :float32 Float/TYPE
+    :float64 Double/TYPE
+    :pointer MemoryAddress
+    :string MemoryAddress))
+
+(defn sig->method-type
+  ^MethodType [{:keys [rettype argtypes]}]
+  (let [^"[Ljava.lang.Class;" cls-ary (->> argtypes
+                                           (map argtype->cls)
+                                           (into-array Class))]
+    (MethodType/methodType (argtype->cls rettype) cls-ary)))
+
+(defn sig->cls-name
+  [{:keys [rettype argtypes]}]
+  (->> (concat [rettype] argtypes)
+       (map (fn [argtype]
+              (if-not (nil? argtype)
+                (case argtype
+                  :int8 "B"
+                  :int16 "S"
+                  :int32 "I"
+                  :int64 "J"
+                  :float32 "F"
+                  :float64 "D"
+                  "P")
+                "V")))
+       (s/join "_")))
+
+(def constructor-code
+  )
+
+(defn argtype->insn-type
+  [argtype]
+  (if (nil? argtype)
+    :void
+    (case argtype
+      :int8 :byte
+      :int16 :short
+      :int32 :int
+      :int64 :long
+      :float32 :float
+      :float64 :double
+      MemoryAddress)))
+
+(defn emit-insn-for-sig
+  [{:keys [rettype argtypes]}]
+  (concat
+   [[:aload 0]
+    [:getfield :this "methodHandle" MethodHandle]]
+   (->> argtypes
+        (map-indexed vector)
+        (mapcat (fn [[idx argtype]]
+                  (let [arg-idx (inc (long idx))]
+                    (concat
+                     [[:aload arg-idx]]
+                     (case argtype
+                       :int8 [[:invokestatic NumericConversions "numberCast" [:object Number]]
+                              [:invokestatic RT "uncheckedByteCast" [:object Byte/TYPE]]]
+                       :int16 [[:invokestatic NumericConversions "numberCast" [:object Number]]
+                               [:invokestatic RT "uncheckedShortCast" [:object Short/TYPE]]]
+                       :int32 [[:invokestatic NumericConversions "numberCast" [:object Number]]
+                               [:invokestatic RT "uncheckedIntCast" [:object Integer/TYPE]]]
+                       :int64 [[:invokestatic NumericConversions "numberCast" [:object Number]]
+                               [:invokestatic RT "uncheckedIntCast" [:object Long/TYPE]]]
+                       :float32 [[:invokestatic NumericConversions "numberCast" [:object Number]]
+                                 [:invokestatic RT "uncheckedFloatCast" [:object Float/TYPE]]]
+                       :float64 [[:invokestatic NumericConversions "numberCast" [:object Number]]
+                                 [:invokestatic RT "uncheckedDoubleCast" [:object Double/TYPE]]]
+                       [[:aload 0]
+                        [:getfield :this "asMemoryAddr" IFn]
+                        ;;Swap the IFn 'this' ptr and the argument on the stack
+                        [:swap]
+                        [:invokeinterface IFn "invoke" [Object Object]]
+                        [:checkcast MemoryAddress]]))))))
+   [
+    (concat [[:invokevirtual MethodHandle "invokeExact" (mapv argtype->insn-type (concat argtypes [rettype]))]]
+            (case rettype
+              :int8 [[:invokestatic Byte "valueOf" [:byte Byte]]
+                     [:areturn]]
+              :int16 [[:invokestatic Short "valueOf" [:short Short]]
+                      [:areturn]]
+              :int32 [[:invokestatic Integer "valueOf" [:int Integer]]
+                      [:areturn]]
+              :int64 [[:invokestatic Long "valueOf" [:long Long]]
+                      [:areturn]]
+              :float32 [[:invokestatic Float "valueOf" [:float Float]]
+                        [:areturn]]
+              :float64 [[:invokestatic Double "valueOf" [:double Double]]
+                        [:areturn]]
+              (if (nil? rettype)
+                [[:return]]
+                [[:areturn]])))]))
+
+
+(defn emit-insn-apply-to
+  [^long n-args]
+  (concat
+   [[:aload 0]
+    [:dup]
+    [:aload 1]]
+   (->> (for [idx (range n-args)]
+          [[:dup]
+           [:invokeinterface ISeq "first" [Object]]
+           [:swap]
+           [:invokeinterface ISeq "next" [ISeq]]])
+        (apply concat))
+   [[:pop]
+    [:invokevirtual :this "invoke" (vec (repeat (inc n-args) Object))]
+    [:areturn]]))
+
+
+(defn sig->class-def
+  [{:keys [argtypes] :as sig}]
+  (let [cls-name (sig->cls-name sig)]
+    {:name (symbol (str "test.v3.datatype.ffi." cls-name))
+     :interfaces [IFn]
+     :fields [{:flags #{:public :final}
+               :name "methodHandle"
+               :type MethodHandle}
+              {:flags #{:public :final}
+               :name "asMemoryAddr"
+               :type IFn}]
+     :methods [{:flags #{:public}
+                :name :init
+                :desc [MethodHandle IFn :void]
+                :emit [[:aload 0]
+                       [:invokespecial :super :init [:void]]
+                       [:aload 0]
+                       [:aload 1]
+                       [:checkcast MethodHandle]
+                       [:putfield :this "methodHandle" MethodHandle]
+                       [:aload 0]
+                       [:aload 2]
+                       [:checkcast IFn]
+                       [:putfield :this "asMemoryAddr" IFn]
+                       [:return]]}
+               {:flags #{:public}
+                :name :invoke
+                :desc (vec (repeat (inc (count argtypes)) Object))
+                :emit (emit-insn-for-sig sig)}
+               {:flags #{:public}
+                :name :applyTo
+                :desc [ISeq Object]
+                :emit (emit-insn-apply-to (count argtypes))}
+               ]}))
+
+(defn strlen
+  [data]
+  (let [linker (CLinker/getInstance)
+        symbol (find-symbol "strlen")
+        sig {:rettype :int64 :argtypes [:pointer]}
+        jvm-sig (sig->method-type sig)
+        c-sig (sig->fdesc sig)
+        mh (.downcallHandle linker symbol jvm-sig c-sig)
+        ms (CLinker/toCString (str data))]
+    (InvokeStub/invokeExactJ mh (.address ms))))

--- a/src_jdk_16/tech/v3/datatype/mmap_ffi.clj
+++ b/src_jdk_16/tech/v3/datatype/mmap_ffi.clj
@@ -1,0 +1,96 @@
+(ns tech.v3.datatype.mmap-ffi
+  (:require [tech.v3.datatype.ffi :as ffi]
+            [tech.v3.datatype.errors :as errors]
+            [tech.v3.datatype.native-buffer :as native-buffer]
+            [tech.v3.resource :as resource])
+  (:import [tech.v3.datatype.native_buffer NativeBuffer]))
+
+
+;;OPENPROT
+(def ^{:tag 'long} O_RDONLY 0)
+(def ^{:tag 'long} O_WRONLY 1)
+(def ^{:tag 'long} O_RDWR 2)
+
+(ffi/def-ffi-fn nil open
+  "Open a file"
+  :int32
+  [:pointer fname]
+  [:int32 openprot])
+
+
+(ffi/def-ffi-fn nil close
+  "Close an opened file"
+  :int32
+  [:int32 fhandle])
+
+;;Unix-based mmap.  Windows will have to wait for someone
+;;with a windows machine
+
+(def ^{:tag 'long} PROT_READ   0x1) ;; Page can be read.
+(def ^{:tag 'long} PROT_WRITE  0x2) ;; Page can be written.
+(def ^{:tag 'long} PROT_EXEC   0x4) ;; Page can be executed.
+(def ^{:tag 'long} PROT_NONE   0x0) ;; Page can not be accessed.
+
+(def ^{:tag 'long} MAP_SHARED  0x01)   ;; Share changes.
+(def ^{:tag 'long} MAP_PRIVATE 0x02)   ;; Changes are private.
+(def ^{:tag 'long} MAP_ANONYMOUS 0x20) ;; Do not use a file backing
+
+
+(ffi/def-ffi-fn nil mmap
+  "mmap a file descriptor, returning a pointer to file-backed"
+  (ffi/ptr-int-type)
+  [(ffi/ptr-int-type) address]
+  [(ffi/size-t-type) length]
+  [:int32 protect]
+  [:int32 flags]
+  [:int32 filedes]
+  [(ffi/size-t-type) offset])
+
+
+(ffi/def-ffi-fn nil munmap
+  "unmap a region"
+  :int32
+  [(ffi/ptr-int-type) address]
+  [(ffi/size-t-type) length])
+
+
+(defn mmap-file
+  "Memory map a file returning a native buffer.  fpath must resolve to a valid
+   java.io.File.
+  Options
+  * :resource-type - maps to tech.v3.resource `:track-type`, defaults to auto.
+  * :mmap-mode
+    * :read-only - default - map the data as shared read-only.
+    * :read-write - map the data as shared read-write."
+  (^NativeBuffer [fpath {:keys [resource-type mmap-mode endianness]
+                         :or {resource-type :auto
+                              mmap-mode :read-only}}]
+   (let [fhandle (long (open fpath (case mmap-mode
+                                     :read-only O_RDONLY
+                                     :read-write O_RDWR)))
+         _ (errors/when-not-errorf
+            (not= -1 fhandle)
+            "Open system call failed--does file exist?")
+         flen (.length (java.io.File. fpath))
+         addr (long (mmap 0 flen MAP_SHARED (case mmap-mode
+                                              :read-only PROT_READ
+                                              :read-write (bit-or
+                                                           PROT_READ
+                                                           PROT_WRITE))
+                          fhandle 0))
+         _ (errors/when-not-error
+            (not= -1 addr)
+            "MMap system call failed")
+         ;;not needed once file is mapped
+         _ (close fhandle)
+         nbuf (native-buffer/wrap-address addr flen :int8 endianness nil)]
+     (when resource-type
+       (resource/track nbuf {:track-type resource-type
+                             :dispose-fn #(munmap addr flen)}))
+     nbuf))
+  (^NativeBuffer [fpath] (mmap-file fpath {})))
+
+
+;; (def ^{:tag 'long} MS_ASYNC 1) ;; Sync memory asynchronously.
+;; (def ^{:tag 'long} MS_SYNC  4) ;; Synchronous memory sync.
+;; (def ^{:tag 'long} MS_INVALIDATE 2) ;; Invalidate the caches.

--- a/src_jdk_16/tech/v3/datatype/mmap_mmodel.clj
+++ b/src_jdk_16/tech/v3/datatype/mmap_mmodel.clj
@@ -1,0 +1,42 @@
+(ns tech.v3.datatype.mmap-mmodel
+  "Mmap based on the MemorySegment jdk16 memory model pathway"
+  (:require [tech.v3.datatype.errors :as errors]
+            [tech.v3.datatype.native-buffer-mmodel :as nbuf-mmodel]
+            [tech.v3.resource :as resource]
+            [tech.v3.datatype.ffi :as ffi])
+  (:import [jdk.incubator.foreign LibraryLookup CLinker FunctionDescriptor
+            MemoryLayout LibraryLookup$Symbol MemorySegment]
+           [java.nio.channels FileChannel$MapMode]
+           [tech.v3.datatype.native_buffer NativeBuffer]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn mmap-file
+  "Memory map a file returning a native buffer.  fpath must resolve to a valid
+   java.io.File.
+  Options
+  * :resource-type - maps to tech.v3.resource `:track-type`, defaults to auto.
+  * :mmap-mode
+    * :read-only - default - map the data as shared read-only.
+    * :read-write - map the data as shared read-write.
+  * :map-len - Override the file's length to provide a mapping length"
+  (^NativeBuffer [fpath {:keys [resource-type mmap-mode]
+                         :or {resource-type :auto
+                              mmap-mode :read-only}
+                         :as options}]
+   (let [flen (long (:map-len options
+                              (.length (java.io.File. (str fpath)))))
+         mseg (-> (MemorySegment/mapFile (ffi/->path fpath) 0 flen
+                                         (case mmap-mode
+                                           :read-only FileChannel$MapMode/READ_ONLY
+                                           :read-write FileChannel$MapMode/READ_WRITE
+                                           :private FileChannel$MapMode/PRIVATE))
+                  (.share))
+         nbuf (nbuf-mmodel/memory-segment->native-buffer mseg options)]
+     (when resource-type
+       (resource/track nbuf {:track-type resource-type
+                             :dispose-fn #(.close mseg)}))
+     nbuf))
+  (^NativeBuffer [fpath] (mmap-file fpath {})))

--- a/src_jdk_16/tech/v3/datatype/native_buffer_mmodel.clj
+++ b/src_jdk_16/tech/v3/datatype/native_buffer_mmodel.clj
@@ -1,0 +1,47 @@
+(ns tech.v3.datatype.native-buffer-mmodel
+  (:require [tech.v3.datatype.protocols :as dtype-proto]
+            [tech.v3.datatype.errors :as errors]
+            [tech.v3.datatype.native-buffer :as native-buffer]
+            [tech.v3.datatype.casting :as casting])
+  (:import [jdk.incubator.foreign MemorySegment MemoryAddress]
+           [tech.v3.datatype.native_buffer NativeBuffer]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn memory-segment->native-buffer
+  (^NativeBuffer [^MemorySegment mseg options]
+   (let [addr (->(.address mseg)
+                 (.toRawLongValue))
+         endianness (:endianness options (dtype-proto/platform-endianness))]
+     (native-buffer/wrap-address addr (.byteSize mseg) :int8 endianness mseg)))
+  (^NativeBuffer [mseg]
+   (memory-segment->native-buffer mseg nil)))
+
+
+(extend-type MemorySegment
+  dtype-proto/PDatatype
+  (datatype [item] :memory-segment)
+  dtype-proto/PElemwiseDatatype
+  (elemwise-datatype [item] :int8)
+  dtype-proto/PECount
+  (ecount [item] (.byteSize item))
+  dtype-proto/PToNativeBuffer
+  (convertible-to-native-buffer? [item] true)
+  (->native-buffer [item] (memory-segment->native-buffer item)))
+
+
+(defn native-buffer->memory-segment
+  ^MemorySegment [item]
+  (errors/when-not-errorf
+   (dtype-proto/convertible-to-native-buffer? item)
+   "Item type (%s) is not convertible to native buffer"
+   (type item))
+  (let [^NativeBuffer nbuf (dtype-proto/->native-buffer item)
+        addr (MemoryAddress/ofLong (.address nbuf))
+        n-bytes (* (dtype-proto/ecount nbuf)
+                   (casting/numeric-byte-width
+                    (dtype-proto/elemwise-datatype nbuf)))]
+    (-> (.asSegmentRestricted addr n-bytes nil nbuf)
+        (.share))))

--- a/src_jdk_16/tech/v3/datatype/nio_buf_mmodel.clj
+++ b/src_jdk_16/tech/v3/datatype/nio_buf_mmodel.clj
@@ -1,0 +1,21 @@
+(ns tech.v3.datatype.nio-buf-mmodel
+  (:require [tech.v3.datatype.protocols :as dtype-proto])
+  (:import [jdk.incubator.foreign MemoryAddress Addressable MemorySegment
+            NativeScope]
+           [java.nio ByteBuffer ByteOrder]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn direct-buffer-constructor
+  ^ByteBuffer [nbuf ^long address ^long nbytes options]
+  (let [retval (-> (MemoryAddress/ofLong address)
+                   (.asSegmentRestricted nbytes nil nbuf)
+                   (.share)
+                   (.asByteBuffer))
+        endianness (dtype-proto/endianness nbuf)]
+    (case endianness
+      :little-endian (.order retval ByteOrder/LITTLE_ENDIAN)
+      :big-endian (.order retval ByteOrder/BIG_ENDIAN))
+    retval))

--- a/test/tech/v3/datatype/nio_buffer_test.clj
+++ b/test/tech/v3/datatype/nio_buffer_test.clj
@@ -1,0 +1,14 @@
+(ns tech.v3.datatype.nio-buffer-test
+  (:require [tech.v3.datatype :as dtype]
+            [tech.v3.datatype.nio-buffer :as nio-buffer]
+            [tech.v3.datatype.native-buffer :as native-buffer]
+            [clojure.test :refer [deftest is]]))
+
+
+(deftest simple-nio-conversion
+  (let [data (dtype/make-container :native-heap :uint8 [255 254 0 1])
+        bdata (nio-buffer/->nio-buffer data)
+        nbuf (-> (dtype/as-native-buffer bdata)
+                 (native-buffer/set-native-datatype :uint8))]
+    (is (= (vec (dtype/->short-array data))
+           (vec (dtype/->short-array nbuf))))))


### PR DESCRIPTION
There is only 1 error that relates to memory mapping.  It is time to put the new FFI interface for java to the test and implement the mmap interface directly on FFI calls.