### PR TITLE
Alternate solution: Remove extra comma in column printing 

### DIFF
--- a/src/tech/v3/datatype/pprint.clj
+++ b/src/tech/v3/datatype/pprint.clj
@@ -28,16 +28,12 @@
         (->> (packing/unpack rdr)
              (dtype-proto/->reader)
              (reduce (fn [^StringBuilder builder val]
+                       (when-not (= 0 (.length builder)) ; not the first element
+                         (.append builder ", "))
                        (.append builder
-                                (formatter val))
-                       (.append builder ", "))
-                     (StringBuilder.)))
-        len (.length builder)]
-    (if (> len 0)
-      (-> builder
-          (.delete (- len 2) len) ; remove the last ", "
-          (.toString))
-      "")))
+                                (formatter val)))
+                     (StringBuilder.)))]
+    (.toString builder)))
 
 
 (defn buffer->string


### PR DESCRIPTION
Relevant conversation can be found [here](https://clojurians.zulipchat.com/#narrow/stream/236259-tech.2Eml.2Edataset.2Edev/topic/extra.20comma.20in.20column.20printing).
Addressing the comments on [this](https://github.com/cnuernber/dtype-next/pull/17) PR.