### PR TITLE
Link broadcast and reduce-axis to each other

### DIFF
--- a/src/tech/v3/datatype/base.clj
+++ b/src/tech/v3/datatype/base.clj
@@ -861,7 +861,9 @@ user> (dtt/transpose tensor [1 2 0])
 
 (defn broadcast
   "Broadcase an element into a new (larger) shape.  The new shape's dimension
-  must be even multiples of the old shape's dimensions.  Elements are repeated."
+  must be even multiples of the old shape's dimensions.  Elements are repeated.
+
+  See [[reduce-axis]] for the opposite operation."
   ^NDBuffer [t new-shape]
   (check-ns 'tech.v3.tensor)
   (dtype-proto/broadcast t new-shape))

--- a/src/tech/v3/tensor.clj
+++ b/src/tech/v3/tensor.clj
@@ -1218,7 +1218,9 @@ user> (dtype/shape (dtt/reduce-axis dfn/sum t 1))
 [2 5]
 user> (dtype/shape (dtt/reduce-axis dfn/sum t 2))
 [2 3]
-```"
+```
+
+  For the opposite - adding dimensions via repetition - see [[broadcast]]."
   ([reduce-fn tensor axis res-dtype]
    (let [rank (count (dtype-base/shape tensor))
          dec-rank (dec rank)


### PR DESCRIPTION
to improve discoverability.

(Using the [[wikilink]] syntax as [recommended](https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#docstrings) by cljdoc.