### PR TITLE
Auto detect when in graal native image buildtime.

### DIFF
--- a/src/tech/v3/datatype/graal_native.clj
+++ b/src/tech/v3/datatype/graal_native.clj
@@ -1,9 +1,17 @@
 (ns tech.v3.datatype.graal-native)
 
+(defmacro ^:private in-image-buildtime-code? []
+  (try
+    (import 'org.graalvm.nativeimage.ImageInfo)
+    `(org.graalvm.nativeimage.ImageInfo/inImageBuildtimeCode)
+    (catch ClassNotFoundException e
+      false)))
 
 (defn graal-native?
   []
-  (= "true" (System/getProperty "tech.v3.datatype.graal-native")))
+  (if-let [graal-native-prop (System/getProperty "tech.v3.datatype.graal-native")]
+    (= "true" graal-native-prop)
+    (in-image-buildtime-code?)))
 
 
 (defmacro when-defined-graal-native


### PR DESCRIPTION
This change will automatically detect when running at graalvm image build time, but still allow overrides via the `tech.v3.datatype.graal-native` System property.

The goal for this change is to make it easier for graalvm compatible libraries to "just work". Passing the `tech.v3.datatype.graal-native` System property should no longer be needed in most cases. However, it does add some more build-time "magic". I'm not sure if you think that's an improvement or not. Requiring the `tech.v3.datatype.graal-native` System property works too.