### PR TITLE
Add clj-kondo handling for export-symbols.

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:hooks {:macroexpand {tech.v3.datatype.export-symbols/export-symbols
+                       hooks.export-symbols/export-symbols}}}

--- a/.clj-kondo/hooks/export_symbols.clj
+++ b/.clj-kondo/hooks/export_symbols.clj
@@ -1,0 +1,32 @@
+(ns hooks.export-symbols)
+
+(defmacro export-symbols
+  [src-ns & symbol-list]
+  `(do
+     (require '~src-ns)
+     ~@(->> symbol-list
+            (mapv
+             (fn [sym-name]
+               `(let [varval# (requiring-resolve (symbol ~(name src-ns)
+                                                         ~(name sym-name)))
+                      var-meta# (meta varval#)]
+                  (when-not varval#
+                    (throw (ex-info
+                            (format "Failed to find symbol '%s' in namespace '%s'"
+                                    ~(name sym-name) ~(name src-ns))
+                            {:symbol '~sym-name
+                             :src-ns '~src-ns})))
+                  (when (:macro var-meta#)
+                    (throw
+                     (ex-info
+                      (format "Cannot export macros as this breaks aot: %s"
+                              '~sym-name)
+                      {:symbol '~sym-name})))
+                  (def ~(symbol (name sym-name)) @varval#)
+                  (alter-meta! #'~(symbol (name sym-name))
+                               merge
+                               (select-keys var-meta#
+                                            [:file :line :column
+                                             :doc
+                                             :column :tag
+                                             :arglists]))))))))

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ jdk-16.0.1
 jdk-17.0.1
 library_test
 zulu-jdk
+.clj-kondo/.cache


### PR DESCRIPTION
Uses the new `:macroexpand` functionality in clj-kondo.

Thx @borkdude for the help on the slack channel.