### PR TITLE
Add to readme note about `libmkl-rt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ reader/writing/copying all work for native and jvm heap datasets.  Tensors work.
 * https://github.com/epiccastle/spire
 * https://github.com/babashka/babashka-sql-pods
 
+## Test Dependencies
+
+* Intel® Math Kernel Library - Use your system package manager to install `libmkl-rt`
 
 ## License
 


### PR DESCRIPTION
Why:
Running tests without its presence results in an error:
```
Execution error (UnsatisfiedLinkError) at jdk.internal.loader.NativeLibraries/load (NativeLibraries.java:-2).
/tmp/libneanderthal-mkl-0.33..so: libmkl_rt.so: cannot open shared object file: No such file or directory
```