### PR TITLE
casting: Add support for :decimal datatypes

### DIFF
--- a/src/tech/v3/datatype/casting.clj
+++ b/src/tech/v3/datatype/casting.clj
@@ -7,6 +7,7 @@
   (:import [java.util Map Set HashSet Collection]
            [java.util.concurrent ConcurrentHashMap]
            [clojure.lang RT Keyword]
+           [java.math BigDecimal]
            [java.util UUID]))
 
 (set! *warn-on-reflection* true)
@@ -643,6 +644,21 @@
 (add-object-datatype! :keyword Keyword)
 (add-cast-fn! :keyword keyword-cast)
 (add-unchecked-cast-fn! :keyword keyword-cast)
+
+(add-object-datatype! :decimal BigDecimal)
+(defn decimal-cast
+  [item]
+  (when item
+    (cond
+      (instance? BigDecimal item)
+      item
+      (string? item)
+      (BigDecimal. ^String item)
+      :else
+      (errors/throwf "Unable to cast item to decimal: %s" item))))
+
+(add-cast-fn! :decimal decimal-cast)
+(add-unchecked-cast-fn! :decimal decimal-cast)
 
 (add-object-datatype! :uuid UUID)
 (defn uuid-cast

--- a/test/tech/v3/datatype/object_arrays_test.clj
+++ b/test/tech/v3/datatype/object_arrays_test.clj
@@ -105,6 +105,19 @@
     (is (= [:a :b :c :d :e :f :g :h :i]
            (vec (.toArray data))))))
 
+(deftest decimal-test
+  (let [test-decimal (bigdec "12.34")
+        decimal-ary (dtype/make-container :java-array :decimal (repeat 5 test-decimal))
+        decimal-list (dtype/make-container :list :decimal (repeat 5 test-decimal))]
+    (is (= :decimal (dtype/get-datatype decimal-ary)))
+    (is (thrown? Throwable (dtype/set-value! decimal-ary 2 "hey")))
+    (is (= (vec (repeat 5 test-decimal))
+           (vec decimal-ary)))
+    (is (= :decimal (dtype/get-datatype decimal-list)))
+    (is (thrown? Throwable (dtype/set-value! decimal-list 2 "hey")))
+    (is (= (vec (repeat 5 test-decimal))
+           (vec decimal-list)))
+    (is (instance? List decimal-list))))
 
 (deftest uuid-test
   (let [test-uuid (UUID/randomUUID)


### PR DESCRIPTION
Registers the :decimal object datatype. I was surprised how little code this took, but it seems to work without issue reading parquet files with :decimal values.