### PR TITLE
Use :estimation-type option in percentiles

### DIFF
--- a/src/tech/v3/datatype/statistics.clj
+++ b/src/tech/v3/datatype/statistics.clj
@@ -415,8 +415,9 @@
   nan-strategy can be one of [:keep :remove :exception] and defaults to :exception."
   (^Buffer [percentages options data]
    (let [ary-buf (dtype-cmc/->array-buffer :float64 options data)
-         p (doto (Percentile.)
-             (.withEstimationType (options->percentile-estimation-strategy options))
+         p (doto (.withEstimationType
+                  (Percentile.)
+                  (options->percentile-estimation-strategy options))
              (.setData ^doubles (.ary-data ary-buf) (.offset ary-buf)
                        (.n-elems ary-buf)))]
      (dtype-base/->reader (mapv #(.evaluate p (double %)) percentages))))

--- a/test/tech/v3/datatype/statistics_test.clj
+++ b/test/tech/v3/datatype/statistics_test.clj
@@ -2,7 +2,7 @@
   (:require [tech.v3.datatype :as dtype]
             [tech.v3.datatype.statistics :as stats]
             [tech.v3.datatype.functional :as dfn]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest is testing]]
             [clojure.data :as cdata]
             [clojure.pprint :as pp]
             [clojure.edn :as edn]))
@@ -33,7 +33,17 @@
          (stats/quartiles test-data)))
     (let [test-fn (stats/quartile-outlier-fn test-data)]
       (is (= [true false false true]
-             (mapv test-fn [-100 15 50 100]))))))
+             (mapv test-fn [-100 15 50 100])))))
+  (testing "an :estimation-type option can be specified"
+    (let [percentiles [25 50 75]
+          data [1 2 3 4 10]]
+      (is (= [1.5 3.0 7.0]
+             (stats/percentiles percentiles data)))
+      (is (= [1.5 3.0 7.0]
+             (stats/percentiles percentiles {:estimation-type :legacy} data)))
+      (is (= [2.0 3.0 4.0]
+             (stats/percentiles percentiles {:estimation-type :r1} data))))))
+
 
 (deftest nan-min-max
   (let [test-data (double-array (edn/read-string (slurp "test/data/double-data.edn")))


### PR DESCRIPTION
The :estimation-type option passed to the percentiles function was not used. This happened because Percentile's withEstimationType method was called to change the EstimationType of the existing Percentile object, but this method returns a new Percentile object with the specified EstimationType instead.

Related docs: [Percentile.withEstimationType](https://commons.apache.org/proper/commons-math/javadocs/api-3.6.1/org/apache/commons/math3/stat/descriptive/rank/Percentile.html#withEstimationType(org.apache.commons.math3.stat.descriptive.rank.Percentile.EstimationType))