### PR TITLE
Fixed type hints in parallel-for

### DIFF
--- a/src/tech/v3/parallel/for.clj
+++ b/src/tech/v3/parallel/for.clj
@@ -136,7 +136,7 @@
   `(let [num-iters# (long ~num-iters)]
      (->> (hamf/upgroups
            num-iters#
-           (fn [^long sidx# ^long eidx#]
+           (fn [^{:tag ~'long} sidx# ^{:tag ~'long} eidx#]
              (let [glen# (- eidx# sidx#)]
                (dotimes [idx# glen#]
                  (let [~idx-var (+ idx# sidx#)]


### PR DESCRIPTION
Playing around a bit more with dtype, I found another minor issue: The [type hints](https://github.com/cnuernber/dtype-next/blob/master/src/tech/v3/parallel/for.clj#L139) in `parallel-for` are incorrect; `^long` in a syntax quote resolves to `{:tag clojure.core/long}` instead of `{:tag 'long}`.
This is not recognized by the Clojure compiler as a valid type hint ([context](https://www.reddit.com/r/Clojure/comments/t2u8iw/comment/hysaxaz/)).

Normally, this does not cause any problems; the hint is simply ignored. However, when invoking the `parallel-for` macro from a Clerk notebook, the expanded form is analyzed via [tools.analyzer.jvm](https://github.com/clojure/tools.analyzer.jvm).
The invalid type hint causes an exception in the analyzer (`ClassNotFoundException`) and prevents the Clerk notebook from loading.
While I think that this is mostly an issue with the way Clerk deals with such errors, I think fixing the error condition in dtype makes sense anyway.

Tests are still passing.