### PR TITLE
Add clj-kondo macro metadata build option

### DIFF
--- a/src/tech/v3/datatype/export_symbols.clj
+++ b/src/tech/v3/datatype/export_symbols.clj
@@ -152,7 +152,7 @@
                 (write! writer (escape-doc-quote (:doc data)))
                 (writeln! writer "\""))
               (let [keys (clj-kondo-keys data)]
-                (when-not (and (empty? keys) (not macro?))
+                (when (and (seq keys) macro?)
                   (indent! writer 2)
                   (write! writer "{")
                   (doseq [key keys]

--- a/src/tech/v3/datatype/export_symbols.clj
+++ b/src/tech/v3/datatype/export_symbols.clj
@@ -159,7 +159,7 @@
                 (when (and (seq meta-str) macro?)
                   (indent! writer 2)
                   (write! writer (format "{%s}" meta-str))
-                 (writeln! writer "")))
+                  (writeln! writer "")))
               (doseq [arglist (:arglists data)]
                 ;;Preprocess the arglist to remove map destructuring and turn anything after
                 ;;the '&' into a generic 'args' argument.

--- a/src/tech/v3/datatype/export_symbols.clj
+++ b/src/tech/v3/datatype/export_symbols.clj
@@ -82,6 +82,12 @@
     (.replace docstr "\"" "\\\"")))
 
 
+(defn- clj-kondo-keys [macro-meta]
+  (->> macro-meta
+       keys
+       (filter (fn [k] (= (namespace k) "clj-kondo")))))
+
+
 (defn write-api!
   "Used to write an easily-discoverable public api.  This simply looks at ns-publics and
   creates stubs that call through to their defined functions and macros.
@@ -145,6 +151,13 @@
                 (write! writer "\"")
                 (write! writer (escape-doc-quote (:doc data)))
                 (writeln! writer "\""))
+              (let [keys (clj-kondo-keys data)]
+                (when-not (and (empty? keys) (not macro?))
+                  (indent! writer 2)
+                  (write! writer "{")
+                  (doseq [key keys]
+                    (write! writer (format "%s %s " key (if (vector? (key data)) (key data) (str "'" (key data))))))
+                  (writeln! writer "}")))
               (doseq [arglist (:arglists data)]
                 ;;Preprocess the arglist to remove map destructuring and turn anything after
                 ;;the '&' into a generic 'args' argument.


### PR DESCRIPTION
### Issue
* While applying clj-kondo linter metadata on `tablecloth/let-dataset` macro in this [PR](https://github.com/scicloj/tablecloth/pull/162), I noticed that `write-api!` doesn't build macro metadata at all. 

### Reason
* I think that clj-kondo is very good linter but It doesn't recognise custom macros which are common in Clojure code afaik.
Usually developers write their own set of rules regarding how clj-kondo is going to behave but I believe that should be the case only for macros that are `internally` used.
I was thinking that it would be beneficial if we could provide build option for linting metadata when macro is built using `write-api!`.
  

### Solution
- With helper function we check for all keys inside macro metadata and return only ones that have `clj-kondo` namespace part. 
- Meta string is being built from those filtered clj-kondo metadata key-pairs.
- Check if meta string is not empty and if macro is being built.
- Feed meta string to writer.
- If macro is not being built or string is empty, step is going to be skipped.


### Why I chose this approach
* I wanted to do this with least invasive approach for the project which would be to force developers to respect certain rules if they want to add metadata that is going to be built.

1. Metadata key must contain "clj-kondo"
2. Metadata can only be built on macros.

* By following [unrecognized-macros](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#unrecognized-macros) docs I saw that there is shorter syntax for adding certain rules but I didn't think that as good approach in this case so I didn't include it in the rules. This way we are certain that only clj-kondo metadata will be added. 

-----------------------------------------------------------------------------------------------------------------------------------

* If there is an issue with this PR or an idea how to make it better I would like to hear it!
My goal is to learn and contribute to open source as much as possible.