### PR TITLE
Add type hint for in `->array`.

### DIFF
--- a/src/tech/v3/datatype/copy_make_container.clj
+++ b/src/tech/v3/datatype/copy_make_container.clj
@@ -166,6 +166,7 @@
     item
     "nil value passed into ->array")
    (let [item (apply-nan-strat datatype nan-strategy item)
+         ^ArrayBuffer
          abuf (dtype-base/as-array-buffer item)]
      (if (and abuf (identical? (.-dtype abuf) (casting/datatype->host-datatype datatype)))
        (if (and (== (.-offset abuf) 0)


### PR DESCRIPTION
I was getting an error in a graalvm native-image app. This type hint seemed to fix the issue.