### PR TITLE
Add ptr t size

### DIFF
--- a/src/tech/v3/datatype/ffi/size_t.clj
+++ b/src/tech/v3/datatype/ffi/size_t.clj
@@ -7,6 +7,9 @@
                     8
                     4))
 
+(def ^{:dynamic true
+       :tag 'long}
+  ptr-t-size size-t-size)
 
 (defmacro with-size-t-size
   [new-size & body]


### PR DESCRIPTION
I sometimes need to calculate the size of buffers with pointers in them. I know `size-t-size` exists and is equivalent to `ptr-size-t` for most practical purposes, but I think `ptr-t-size` helps more clearly express intent in these situations. I dunno, maybe it's unnecessary.