### PR TITLE
Add `:deps/prep-lib` to deps.edn to support usage as a git dep.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,9 @@
         techascent/tech.resource {:mvn/version "5.08"}
         com.cnuernber/ham-fisted {:mvn/version "2.017"}
         org.clj-commons/primitive-math {:mvn/version "1.0.0"}}
+ :deps/prep-lib {:alias :build
+                 :fn compile
+                 :ensure "target/classes"}
  :aliases
  {:codox
   {:extra-deps {codox-theme-rdash/codox-theme-rdash {:mvn/version "0.1.2"}


### PR DESCRIPTION
I'm not sure you're interested in offering dtype-next as a git dep. This pull request only calls `clojure -T:build compile`. I think this matches `scripts/*`, but could get out of sync in the future if additional steps are required.