### PR TITLE
Ergonomics

### DIFF
--- a/src/tech/v3/datatype/native_buffer.clj
+++ b/src/tech/v3/datatype/native_buffer.clj
@@ -934,7 +934,10 @@
                       datatype endianness #{:gc} nil nil gc-obj))))
   (^NativeBuffer [address n-bytes gc-obj]
    (wrap-address address n-bytes :int8 (dtype-proto/platform-endianness)
-                 gc-obj)))
+                 gc-obj))
+  (^NativeBuffer [address n-bytes]
+   (wrap-address address n-bytes :int8 (dtype-proto/platform-endianness)
+                 nil)))
 
 
 (defmacro ^:private check-bounds

--- a/src/tech/v3/tensor.clj
+++ b/src/tech/v3/tensor.clj
@@ -489,7 +489,9 @@ user> (dtt/transpose tensor [1 2 0])
   [:b :b :b]]]
 ```"
   (^{:tag tech.v3.datatype.NDBuffer} [tens reorder-indexes]
-  (tech.v3.datatype.base/transpose tens reorder-indexes)))
+  (tech.v3.datatype.base/transpose tens reorder-indexes))
+  (^{:tag tech.v3.datatype.NDBuffer} [tens]
+  (tech.v3.datatype.base/transpose tens (reverse (range (count (tech.v3.datatype.base/shape tens)))))))
 
 
 (defmacro typed-compute-tensor


### PR DESCRIPTION
These changes are just for convenience.

I wasn't sure `(dtt/tranpose my-tensor)` made sense for higher dimensional tensors, but this behavior matches the defaults for tensor flow's transpose, https://www.tensorflow.org/api_docs/python/tf/transpose.