### PR TITLE
Enable finalized FFI on jdk-22+

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -110,6 +110,8 @@
               "--enable-native-access=ALL-UNNAMED"]}
   :jdk-19
   {:jvm-opts ["--enable-native-access=ALL-UNNAMED"]}
+  :jdk-25
+  {:jvm-opts ["--enable-native-access=ALL-UNNAMED"]}
   :codegen
   {:extra-paths ["src" "dev"]
    :exec-fn tech.v3.datatype.codegen/-main}

--- a/scripts/enable-jdk25
+++ b/scripts/enable-jdk25
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+VERSION="25"
+
+if [ ! -e jdk-$VERSION ]; then
+   echo "Downloading JDK $VERSION"
+    wget https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz
+    tar -xvzf openjdk-25_linux-x64_bin.tar.gz
+    rm openjdk-25_linux-x64_bin.tar.gz
+fi
+
+export PATH=$(pwd)/jdk-$VERSION/bin:$PATH
+export JAVA_HOME=$(pwd)/jdk-$VERSION/

--- a/scripts/enable-jdk25-m1
+++ b/scripts/enable-jdk25-m1
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+VERSION="25"
+
+if [ ! -e jdk-$VERSION ]; then
+   echo "Downloading JDK $VERSION"
+    wget https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_macos-aarch64_bin.tar.gz
+    tar -xvzf openjdk-25_macos-aarch64_bin.tar.gz
+    rm openjdk-25_macos-aarch64_bin.tar.gz
+fi
+
+export PATH=$(pwd)/jdk-$VERSION/bin:$PATH
+export JAVA_HOME=$(pwd)/jdk-$VERSION/

--- a/src/tech/v3/datatype/ffi/mmodel_jdk.clj
+++ b/src/tech/v3/datatype/ffi/mmodel_jdk.clj
@@ -1,4 +1,5 @@
-(ns tech.v3.datatype.ffi.mmodel-jdk21
+(ns tech.v3.datatype.ffi.mmodel-jdk
+  "JDK FFM API implementation - finalized in JDK 22 (JEP 454), available in LTS starting with JDK 25."
   (:require [tech.v3.datatype.errors :as errors]
             [tech.v3.datatype.ffi :as ffi]
             [tech.v3.datatype.ffi.base :as ffi-base]
@@ -188,7 +189,7 @@
       (when-not (= argtype 'by-value)
         (throw (RuntimeException. (str "Invalid argument type: " argtype))))
       [[:ldc (name argname)]
-       [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$by_value_arg
+       [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$by_value_arg
         'invokeStatic [Object Object]]])))
 
 (defn emit-lib-constructor
@@ -199,7 +200,7 @@
      [:invokespecial :super :init [:void]]]
     [[:aload 0]
      [:aload 1]
-     [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$load_library
+     [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$load_library
       'invokeStatic [Object Object]]
      [:checkcast SymbolLookup]
      [:putfield :this "libraryImpl" SymbolLookup]]
@@ -224,7 +225,7 @@
                       [:pop]]))
                   argtypes)
           [[:aload 2]
-           [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$library_sym_method_handle
+           [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$library_sym_method_handle
             'invokeStatic
             [Object Object Object Object Object]]
            [:checkcast MethodHandle]
@@ -243,7 +244,7 @@
   [[:aload 0]
     [:getfield :this "libraryImpl" SymbolLookup]
     [:aload 1]
-    [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$find_symbol
+    [:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$find_symbol
       'invokeStatic [Object Object Object]]
     [:checkcast MemorySegment]
     [:invokeinterface MemorySegment 'address [:long]]
@@ -252,12 +253,12 @@
 
 
 (def ptr-cast
-  [[:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$ptr_value
+  [[:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$ptr_value
       'invokeStatic [Object Object]]
     [:checkcast MemorySegment]])
 
 (def ptr?-cast
-  [[:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$ptr_value_q
+  [[:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$ptr_value_q
       'invokeStatic [Object Object]]
     [:checkcast MemorySegment]])
 
@@ -294,7 +295,7 @@
           [[:aload 0]
            [:getfield :this hdl-name MethodHandle]]
           (when byval-ret?
-            [[:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk21$active_allocator
+            [[:invokestatic 'tech.v3.datatype.ffi.mmodel_jdk$active_allocator
               'invokeStatic [Object]]
              [:checkcast SegmentAllocator]])
           (ffi-base/load-ffi-args ptr-cast ptr?-cast argtypes)

--- a/src/tech/v3/datatype/ffi/native_buffer_mmodel_jdk.clj
+++ b/src/tech/v3/datatype/ffi/native_buffer_mmodel_jdk.clj
@@ -1,4 +1,5 @@
-(ns tech.v3.datatype.ffi.native-buffer-mmodel-jdk21
+(ns tech.v3.datatype.ffi.native-buffer-mmodel-jdk
+  "JDK FFM API MemorySegment support - finalized in JDK 22 (JEP 454), available in LTS starting with JDK 25."
   (:require [tech.v3.datatype.protocols :as dtype-proto]
             [tech.v3.datatype.errors :as errors]
             [tech.v3.datatype.native-buffer :as native-buffer]

--- a/src/tech/v3/datatype/ffi/nio_buf_mmodel_jdk.clj
+++ b/src/tech/v3/datatype/ffi/nio_buf_mmodel_jdk.clj
@@ -1,4 +1,5 @@
-(ns tech.v3.datatype.ffi.nio-buf-mmodel-jdk21
+(ns tech.v3.datatype.ffi.nio-buf-mmodel-jdk
+  "JDK FFM API NIO ByteBuffer support - finalized in JDK 22 (JEP 454), available in LTS starting with JDK 25."
   (:require [tech.v3.datatype.protocols :as dtype-proto])
   (:import [java.lang.foreign MemorySegment]
            [java.nio ByteBuffer ByteOrder]))

--- a/src/tech/v3/datatype/mmap.clj
+++ b/src/tech/v3/datatype/mmap.clj
@@ -39,9 +39,9 @@
               (errors/throwf "Automatic resolution of mmap pathways is disabled for graal native. Please use 'tech.3.datatype.mmap/set-mmap-impl!' prior to calling mmap-file.")
               (let [jdk-version (jdk-major-version)]
                 (try
-                  (requiring-resolve 'tech.v3.datatype.mmap.mmodel-jdk21/mmap-file)
+                  (requiring-resolve 'tech.v3.datatype.mmap.mmodel-jdk/mmap-file)
                   (catch Throwable _e
-                    (log/warn "Failed to activate JDK-21 mmodel pathway; attempting jdk-19.")
+                    (log/warn "Failed to activate JDK (21+) mmodel pathway; attempting jdk-19.")
                     (try
                       (requiring-resolve 'tech.v3.datatype.mmap.mmodel-jdk19/mmap-file)
                       (catch Throwable _e

--- a/src/tech/v3/datatype/mmap/mmodel_jdk.clj
+++ b/src/tech/v3/datatype/mmap/mmodel_jdk.clj
@@ -1,6 +1,6 @@
-(ns tech.v3.datatype.mmap.mmodel-jdk21
-  "Mmap based on the MemorySegment jdk21 memory model pathway"
-  (:require [tech.v3.datatype.ffi.native-buffer-mmodel-jdk21 :as nbuf-mmodel]
+(ns tech.v3.datatype.mmap.mmodel-jdk
+  "Mmap based on the MemorySegment JDK FFM API - finalized in JDK 22 (JEP 454), available in LTS starting with JDK 25."
+  (:require [tech.v3.datatype.ffi.native-buffer-mmodel-jdk :as nbuf-mmodel]
             [tech.v3.resource :as resource])
   (:import [java.lang.foreign MemorySegment Arena]
            [java.nio.channels FileChannel$MapMode FileChannel]

--- a/src/tech/v3/datatype/nio_buffer.clj
+++ b/src/tech/v3/datatype/nio_buffer.clj
@@ -117,7 +117,7 @@
                (resource/chain-resources retval nbuf)))
            (do
              (try
-               (requiring-resolve 'tech.v3.datatype.ffi.nio-buf-mmodel-jdk21/direct-buffer-constructor)
+               (requiring-resolve 'tech.v3.datatype.ffi.nio-buf-mmodel-jdk/direct-buffer-constructor)
                (catch Exception e
                  (log/info "Unable to find direct buffer constructor -
 falling back to jdk19 memory model.")
@@ -129,9 +129,12 @@ falling back to jdk16 memory model.")
                      (try
                        (requiring-resolve 'tech.v3.datatype.ffi.nio-buf-mmodel/direct-buffer-constructor)
                        (catch Exception e
-                         (throw (RuntimeException. "Unable to load direct buffer constructor.  If you are using JDK-17, set your runtime :jvm-opts as follows:
-:jvm-opts [\"--add-modules\" \"jdk.incubator.foreign,jdk.incubator.vector\"
-                         \"--enable-native-access=ALL-UNNAMED\"]}"
+                         (throw (RuntimeException. "Unable to load direct buffer constructor.
+For JDK 17-21, set your runtime :jvm-opts as follows:
+  :jvm-opts [\"--add-modules\" \"jdk.incubator.foreign,jdk.incubator.vector\"
+             \"--enable-native-access=ALL-UNNAMED\"]
+For JDK 22+, only this is needed:
+  :jvm-opts [\"--enable-native-access=ALL-UNNAMED\"]"
                                                    e))))))))))))
 
 


### PR DESCRIPTION
Now that https://openjdk.org/jeps/454 has both landed and made it to LTS, maybe worth updating to call this just "jdk" instead of having to append various preview jdk numbers to each. This PR stabilizes what was 21 as just jdk, aliases jdk-21 to it, and adds the jdk-25 lts to the compile and test scripts.