### PR TITLE
Fix pointer-returning foreign interfaces on the jdk backend

### DIFF
--- a/src/tech/v3/datatype/ffi/mmodel_jdk.clj
+++ b/src/tech/v3/datatype/ffi/mmodel_jdk.clj
@@ -396,16 +396,16 @@
 (defn define-foreign-interface
   [rettype argtypes options]
   (let [classname (or (:classname options)
-                      (symbol (str "tech.v3.datatype.ffi.mmodel.ffi_"
+                      (symbol (str "tech.v3.datatype.ffi.mmodel_jdk.ffi_"
                                    (name (gensym)))))
         retval    (ffi-base/define-foreign-interface classname
                     rettype
                     argtypes
-                    {:src-ns-str "tech.v3.datatype.ffi.mmodel"
+                    {:src-ns-str "tech.v3.datatype.ffi.mmodel_jdk"
                      :platform-ptr->ptr platform-ptr->ptr
                      :ptr->platform-ptr
                      (partial ffi-base/ptr->platform-ptr
-                              "tech.v3.datatype.ffi.mmodel"
+                              "tech.v3.datatype.ffi.mmodel_jdk"
                               MemorySegment)
                      :ptrtype MemorySegment})
         iface-cls (:foreign-iface-class retval)

--- a/test/tech/v3/datatype/ffi_test.clj
+++ b/test/tech/v3/datatype/ffi_test.clj
@@ -68,6 +68,27 @@
   (dt-ffi/set-ffi-impl! :jna)
   (generic-define-library))
 
+
+(deftest jdk-ptr-return-callback-test
+  (dt-ffi/set-ffi-impl! :jdk)
+  (let [qsort (:qsort @(dt-ffi/instantiate-library
+                        (dt-ffi/define-library
+                          {:qsort {:rettype :void
+                                   :argtypes [['d :pointer] ['n :size-t]
+                                              ['sz :size-t] ['cmp :pointer]]}}
+                          nil nil) nil))
+        cmp (dt-ffi/define-foreign-interface :pointer [:pointer :pointer])
+        cmp-ptr (dt-ffi/foreign-interface-instance->c
+                 cmp (dt-ffi/instantiate-foreign-interface
+                      cmp (fn [^Pointer a ^Pointer b]
+                            (dt-ffi/->pointer
+                             (long (Double/compare
+                                    (.getDouble (native-buffer/unsafe) (.address a))
+                                    (.getDouble (native-buffer/unsafe) (.address b))))))))
+        buf (dtype/make-container :native-heap :float64 (shuffle (range 100)))]
+    (qsort buf 100 Double/BYTES cmp-ptr)
+    (is (dfn/equals buf (range 100)))))
+
 (defn nested-byvalue
   []
   (let [anon1 (dt-struct/define-datatype! :anon1 [{:name :a :datatype :int32}


### PR DESCRIPTION
Follow-up to #131. When I renamed `mmodel_jdk21` -> `mmodel_jdk` there, I missed the hardcoded namespace strings in `mmodel-jdk/define-foreign-interface`: it still generated the callback's return-value Pointer->platform conversion against `tech.v3.datatype.ffi.mmodel` (the pre-19 backend), which isn't loaded on JDK 22+. 

This points those strings at `mmodel_jdk`. Also added a `:pointer`-returning `qsort` comparator test that reproduces it.